### PR TITLE
PayEx redirect response is optional

### DIFF
--- a/src/PayEx.EPi.Commerce.Payment/Contracts/IPaymentInitializer.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Contracts/IPaymentInitializer.cs
@@ -1,10 +1,11 @@
-﻿using PayEx.EPi.Commerce.Payment.Models;
+﻿using System;
+using PayEx.EPi.Commerce.Payment.Models;
 using PayEx.EPi.Commerce.Payment.Models.PaymentMethods;
 
 namespace PayEx.EPi.Commerce.Payment.Contracts
 {
     internal interface IPaymentInitializer
     {
-        PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef);
+        PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef, Action<string> redirectAction);
     }
 }

--- a/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/GenerateOrderNumber.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/GenerateOrderNumber.cs
@@ -1,4 +1,5 @@
-﻿using log4net;
+﻿using System;
+using log4net;
 using PayEx.EPi.Commerce.Payment.Contracts;
 using PayEx.EPi.Commerce.Payment.Contracts.Commerce;
 using PayEx.EPi.Commerce.Payment.Models;
@@ -18,7 +19,7 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
             _orderNumberGenerator = orderNumberGenerator;
         }
 
-        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef)
+        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef, Action<string> redirectAction)
         {
             Log.InfoFormat("Generating order number for payment with ID:{0} belonging to order with ID: {1}", currentPayment.Payment.Id, currentPayment.OrderGroupId);
             if (string.IsNullOrWhiteSpace(orderNumber))
@@ -38,7 +39,7 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
             }
 
             Log.InfoFormat("Finished generating order number for payment with ID:{0} belonging to order with ID: {1}", currentPayment.Payment.Id, currentPayment.OrderGroupId);
-            return _initializer.Initialize(currentPayment, orderNumber, returnUrl, orderRef);
+            return _initializer.Initialize(currentPayment, orderNumber, returnUrl, orderRef, redirectAction);
         }
     }
 }

--- a/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/GetConsumerLegalAddress.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/GetConsumerLegalAddress.cs
@@ -22,7 +22,7 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
             _paymentActions = paymentActions;
         }
 
-        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef)
+        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef, Action<string> redirectAction)
         {
             Log.InfoFormat("Retrieving consumer legal address for payment with ID:{0} belonging to order with ID: {1}", currentPayment.Payment.Id, currentPayment.OrderGroupId);
             CustomerDetails customerDetails = CreateModel(currentPayment);
@@ -36,7 +36,7 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
             _paymentActions.UpdateConsumerInformation(currentPayment, result);
             Log.InfoFormat("Successfully retrieved consumer legal address for payment with ID:{0} belonging to order with ID: {1}", currentPayment.Payment.Id, currentPayment.OrderGroupId);
 
-            return _paymentInitializer.Initialize(currentPayment, orderNumber, returnUrl, orderRef);
+            return _paymentInitializer.Initialize(currentPayment, orderNumber, returnUrl, orderRef, redirectAction);
         }
 
         private CustomerDetails CreateModel(PaymentMethod currentPayment)

--- a/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/GetConsumerLegalAddressForFinancingInvoice.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/GetConsumerLegalAddressForFinancingInvoice.cs
@@ -25,7 +25,7 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
             _updateAddressHandler = updateAddressHandler;
         }
 
-        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef)
+        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef, Action<string> redirectAction)
         {
             if (currentPayment.RequireAddressUpdate)
             {
@@ -59,7 +59,7 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
                     currentPayment.Payment.Id, currentPayment.OrderGroupId);                
             }
 
-            return _paymentInitializer.Initialize(currentPayment, orderNumber, returnUrl, orderRef);
+            return _paymentInitializer.Initialize(currentPayment, orderNumber, returnUrl, orderRef, redirectAction);
         }
 
         private static ConsumerLegalAddressResult ConvertToConsumerAddress(LegalAddressResult result)

--- a/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/InitializePayment.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/InitializePayment.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using EPiServer.Globalization;
 using log4net;
 using PayEx.EPi.Commerce.Payment.Contracts;
@@ -29,7 +30,7 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
             _additionalValuesFormatter = additionalValuesFormatter;
         }
 
-        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef)
+        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef, Action<string> redirectAction)
         {
             Log.InfoFormat("Initializing payment with ID:{0} belonging to order with ID: {1}", currentPayment.Payment.Id, currentPayment.OrderGroupId);
             PaymentInformation paymentInformation = CreateModel(currentPayment, orderNumber);
@@ -44,7 +45,7 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
             _cartActions.UpdateCartInstanceId(currentPayment.Cart); // Save all the changes that have been done to the cart
 
             if (_paymentInitializer != null)
-                return _paymentInitializer.Initialize(currentPayment, orderNumber, result.RedirectUrl, result.OrderRef.ToString());
+                return _paymentInitializer.Initialize(currentPayment, orderNumber, result.RedirectUrl, result.OrderRef.ToString(), redirectAction);
 
             return new PaymentInitializeResult { Success = true };
         }

--- a/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/PurchaseFinancingInvoice.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/PurchaseFinancingInvoice.cs
@@ -20,7 +20,7 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
             _paymentActions = paymentActions;
         }
 
-        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef)
+        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef, Action<string> redirectAction)
         {
             Log.InfoFormat("Calling PurchaseFinancingInvoice for payment with ID:{0} belonging to order with ID: {1}", currentPayment.Payment.Id, currentPayment.OrderGroupId);
             CustomerDetails customerDetails = CreateModel(currentPayment);

--- a/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/PurchaseInvoiceSale.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/PurchaseInvoiceSale.cs
@@ -20,7 +20,7 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
             _paymentActions = paymentActions;
         }
 
-        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef)
+        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef, Action<string> redirectAction)
         {
             Log.InfoFormat("Calling PurchaseInvoiceSale for payment with ID:{0} belonging to order with ID: {1}", currentPayment.Payment.Id, currentPayment.OrderGroupId);
             CustomerDetails customerDetails = CreateModel(currentPayment);

--- a/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/PurchasePartPaymentSale.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/PurchasePartPaymentSale.cs
@@ -20,7 +20,7 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
             _paymentActions = paymentActions;
         }
 
-        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef)
+        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef, Action<string> redirectAction)
         {
             Log.InfoFormat("Calling PurchasePartPaymentSale for payment with ID:{0} belonging to order with ID: {1}", currentPayment.Payment.Id, currentPayment.OrderGroupId);
             CustomerDetails customerDetails = CreateModel(currentPayment);

--- a/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/RedirectUser.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Dectorators/PaymentInitializers/RedirectUser.cs
@@ -1,4 +1,5 @@
-﻿using System.Web;
+﻿using System;
+using System.Web;
 using log4net;
 using PayEx.EPi.Commerce.Payment.Contracts;
 using PayEx.EPi.Commerce.Payment.Models;
@@ -10,14 +11,21 @@ namespace PayEx.EPi.Commerce.Payment.Dectorators.PaymentInitializers
     {
         protected readonly ILog Log = LogManager.GetLogger(Constants.Logging.DefaultLoggerName);
 
-        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef)
+        public PaymentInitializeResult Initialize(PaymentMethod currentPayment, string orderNumber, string returnUrl, string orderRef, Action<string> redirectAction)
         {
             PaymentInitializeResult result = new PaymentInitializeResult();
             Log.InfoFormat("Begin redirect to PayEx for payment with ID:{0} belonging to order with ID: {1}.", currentPayment.Payment.Id, currentPayment.OrderGroupId);
             if (!string.IsNullOrWhiteSpace(returnUrl))
             {
-                Log.InfoFormat("Redirecting user PayEx for payment with ID:{0} belonging to order with ID: {1}. ReturnUrl: {2}", currentPayment.Payment.Id, currentPayment.OrderGroupId, returnUrl);
-                HttpContext.Current.Response.Redirect(returnUrl, true);
+                if (redirectAction != null)
+                {
+                    redirectAction(returnUrl);
+                }
+                else
+                {
+                    Log.InfoFormat("Redirecting user PayEx for payment with ID:{0} belonging to order with ID: {1}. ReturnUrl: {2}", currentPayment.Payment.Id, currentPayment.OrderGroupId, returnUrl);
+                    HttpContext.Current.Response.Redirect(returnUrl, true);   
+                }
                 result.Success = true;
                 return result;
             }

--- a/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/CreditCard.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/CreditCard.cs
@@ -1,4 +1,5 @@
-﻿using PayEx.EPi.Commerce.Payment.Contracts;
+﻿using System;
+using PayEx.EPi.Commerce.Payment.Contracts;
 using PayEx.EPi.Commerce.Payment.Contracts.Commerce;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCapturers;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCompleters;
@@ -56,12 +57,12 @@ namespace PayEx.EPi.Commerce.Payment.Models.PaymentMethods
             get { return PurchaseOperation.AUTHORIZATION; }
         }
 
-        public override PaymentInitializeResult Initialize()
+        public override PaymentInitializeResult Initialize(Action<string> redirectAction)
         {
             IPaymentInitializer initializer = new GenerateOrderNumber(
                     new InitializePayment(
                     new RedirectUser(), _paymentManager, _parameterReader, _cartActions, _additionalValuesFormatter), _orderNumberGenerator);
-            return initializer.Initialize(this, null, null, null);
+            return initializer.Initialize(this, null, null, null, redirectAction);
         }
 
         public override PaymentCompleteResult Complete(string orderRef)

--- a/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/DirectBankDebit.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/DirectBankDebit.cs
@@ -1,4 +1,5 @@
-﻿using PayEx.EPi.Commerce.Payment.Contracts;
+﻿using System;
+using PayEx.EPi.Commerce.Payment.Contracts;
 using PayEx.EPi.Commerce.Payment.Contracts.Commerce;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCompleters;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCreditors;
@@ -55,12 +56,12 @@ namespace PayEx.EPi.Commerce.Payment.Models.PaymentMethods
             get { return PurchaseOperation.SALE; }
         }
 
-        public override PaymentInitializeResult Initialize()
+        public override PaymentInitializeResult Initialize(Action<string> redirectAction)
         {
             IPaymentInitializer initializer = new GenerateOrderNumber(
                 new InitializePayment(
                 new RedirectUser(), _paymentManager, _parameterReader, _cartActions, _additionalValuesFormatter), _orderNumberGenerator);
-            return initializer.Initialize(this, null, null, null);
+            return initializer.Initialize(this, null, null, null, redirectAction);
         }
 
         public override PaymentCompleteResult Complete(string orderRef)

--- a/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/FinancingInvoice.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/FinancingInvoice.cs
@@ -1,4 +1,5 @@
-﻿using PayEx.EPi.Commerce.Payment.Contracts;
+﻿using System;
+using PayEx.EPi.Commerce.Payment.Contracts;
 using PayEx.EPi.Commerce.Payment.Contracts.Commerce;
 using PayEx.EPi.Commerce.Payment.Dectorators.AdditionalValuesFormatters;
 using PayEx.EPi.Commerce.Payment.Dectorators.ParameterReaders;
@@ -89,14 +90,14 @@ namespace PayEx.EPi.Commerce.Payment.Models.PaymentMethods
             }
         }
 
-        public override PaymentInitializeResult Initialize()
+        public override PaymentInitializeResult Initialize(Action<string> redirectAction)
         {
             IPaymentInitializer initializer = new GenerateOrderNumber(
                 new GetConsumerLegalAddressForFinancingInvoice(
                     new InitializePayment(
                         new PurchaseFinancingInvoice(_paymentManager, _paymentActions), _paymentManager, _parameterReader, _cartActions, _additionalValuesFormatter)
                         , _paymentActions, _paymentManager, _updateAddressHandler), _orderNumberGenerator);
-            return initializer.Initialize(this, null, null, null);
+            return initializer.Initialize(this, null, null, null, null);
         }
 
         public override PaymentCompleteResult Complete(string orderRef)

--- a/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/GiftCard.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/GiftCard.cs
@@ -1,4 +1,5 @@
-﻿using PayEx.EPi.Commerce.Payment.Contracts;
+﻿using System;
+using PayEx.EPi.Commerce.Payment.Contracts;
 using PayEx.EPi.Commerce.Payment.Contracts.Commerce;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCapturers;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCompleters;
@@ -56,12 +57,12 @@ namespace PayEx.EPi.Commerce.Payment.Models.PaymentMethods
             get { return PurchaseOperation.AUTHORIZATION; }
         }
 
-        public override PaymentInitializeResult Initialize()
+        public override PaymentInitializeResult Initialize(Action<string> redirectAction)
         {
             IPaymentInitializer initializer = new GenerateOrderNumber(
                 new InitializePayment(
                 new RedirectUser(), _paymentManager, _parameterReader, _cartActions, _additionalValuesFormatter), _orderNumberGenerator);
-            return initializer.Initialize(this, null, null, null);
+            return initializer.Initialize(this, null, null, null, redirectAction);
         }
 
         public override PaymentCompleteResult Complete(string orderRef)

--- a/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/Invoice.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/Invoice.cs
@@ -1,4 +1,5 @@
-﻿using PayEx.EPi.Commerce.Payment.Contracts;
+﻿using System;
+using PayEx.EPi.Commerce.Payment.Contracts;
 using PayEx.EPi.Commerce.Payment.Contracts.Commerce;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCapturers;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCreditors;
@@ -56,14 +57,14 @@ namespace PayEx.EPi.Commerce.Payment.Models.PaymentMethods
             get { return PurchaseOperation.AUTHORIZATION; }
         }
 
-        public override PaymentInitializeResult Initialize()
+        public override PaymentInitializeResult Initialize(Action<string> redirectAction)
         {
             IPaymentInitializer initializer = new GenerateOrderNumber(
                 new GetConsumerLegalAddress(
                     new InitializePayment(
                         new PurchaseInvoiceSale(_paymentManager, _paymentActions), _paymentManager, _parameterReader, _cartActions, _additionalValuesFormatter),
                         _verificationManager, _paymentActions), _orderNumberGenerator);
-            return initializer.Initialize(this, null, null, null);
+            return initializer.Initialize(this, null, null, null, null);
         }
 
         public override PaymentCompleteResult Complete(string orderRef)

--- a/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/InvoiceLedger.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/InvoiceLedger.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using log4net;
 using PayEx.EPi.Commerce.Payment.Contracts;
 using PayEx.EPi.Commerce.Payment.Contracts.Commerce;
@@ -60,12 +61,12 @@ namespace PayEx.EPi.Commerce.Payment.Models.PaymentMethods
             get { return PurchaseOperation.AUTHORIZATION; }
         }
 
-        public override PaymentInitializeResult Initialize()
+        public override PaymentInitializeResult Initialize(Action<string> redirectAction)
         {
             IPaymentInitializer initializer = new GenerateOrderNumber(
                  new InitializePayment(
                  new RedirectUser(), _paymentManager, _parameterReader, _cartActions, _additionalValuesFormatter), _orderNumberGenerator);
-            return initializer.Initialize(this, null, null, null);
+            return initializer.Initialize(this, null, null, null, redirectAction);
         }
 
         public override PaymentCompleteResult Complete(string orderRef)

--- a/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/MasterPass.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/MasterPass.cs
@@ -74,14 +74,14 @@ namespace PayEx.EPi.Commerce.Payment.Models.PaymentMethods
             get { return PurchaseOperation.AUTHORIZATION; }
         }
 
-        public override PaymentInitializeResult Initialize()
+        public override PaymentInitializeResult Initialize(Action<string> redirectAction)
         {
             IPaymentInitializer initializer = new GenerateOrderNumber(
                 new InitializePayment(
                 new RedirectUser(), _paymentManager, _parameterReader, _cartActions, _additionalValuesFormatter),
                 _orderNumberGenerator);
 
-            return initializer.Initialize(this, null, null, null);
+            return initializer.Initialize(this, null, null, null, redirectAction);
         }
 
         public override PaymentCompleteResult Complete(string orderRef)

--- a/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/PartPayment.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/PartPayment.cs
@@ -1,4 +1,5 @@
-﻿using PayEx.EPi.Commerce.Payment.Contracts;
+﻿using System;
+using PayEx.EPi.Commerce.Payment.Contracts;
 using PayEx.EPi.Commerce.Payment.Contracts.Commerce;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCapturers;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCreditors;
@@ -58,12 +59,12 @@ namespace PayEx.EPi.Commerce.Payment.Models.PaymentMethods
             get { return PurchaseOperation.AUTHORIZATION; }
         }
 
-        public override PaymentInitializeResult Initialize()
+        public override PaymentInitializeResult Initialize(Action<string> redirectAction)
         {
             IPaymentInitializer initializer = new GenerateOrderNumber(
                   new InitializePayment(
                   new PurchasePartPaymentSale(_paymentManager, _paymentActions), _paymentManager, _parameterReader, _cartActions, _additionalValuesFormatter), _orderNumberGenerator);
-            return initializer.Initialize(this, null, null, null);
+            return initializer.Initialize(this, null, null, null, null);
         }
 
         public override PaymentCompleteResult Complete(string orderRef)

--- a/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/PayPal.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/PayPal.cs
@@ -1,4 +1,5 @@
-﻿using PayEx.EPi.Commerce.Payment.Contracts;
+﻿using System;
+using PayEx.EPi.Commerce.Payment.Contracts;
 using PayEx.EPi.Commerce.Payment.Contracts.Commerce;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCapturers;
 using PayEx.EPi.Commerce.Payment.Dectorators.PaymentCompleters;
@@ -56,12 +57,12 @@ namespace PayEx.EPi.Commerce.Payment.Models.PaymentMethods
             get { return PurchaseOperation.AUTHORIZATION; }
         }
 
-        public override PaymentInitializeResult Initialize()
+        public override PaymentInitializeResult Initialize(Action<string> redirectAction)
         {
             IPaymentInitializer initializer = new GenerateOrderNumber(
                 new InitializePayment(
                 new RedirectUser(), _paymentManager, _parameterReader, _cartActions, _additionalValuesFormatter), _orderNumberGenerator);
-            return initializer.Initialize(this, null, null, null);
+            return initializer.Initialize(this, null, null, null, redirectAction);
         }
 
         public override PaymentCompleteResult Complete(string orderRef)

--- a/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/PaymentMethod.cs
+++ b/src/PayEx.EPi.Commerce.Payment/Models/PaymentMethods/PaymentMethod.cs
@@ -72,7 +72,7 @@ namespace PayEx.EPi.Commerce.Payment.Models.PaymentMethods
         public abstract bool RequireAddressUpdate { get; }
         public abstract bool IsDirectModel { get; }
         public abstract PurchaseOperation PurchaseOperation { get; }
-        public abstract PaymentInitializeResult Initialize();
+        public abstract PaymentInitializeResult Initialize(Action<string> redirectAction);
         public abstract PaymentCompleteResult Complete(string orderRef);
         public abstract bool Capture();
         public abstract bool Credit();

--- a/src/PayEx.EPi.Commerce.Payment/PayExPaymentGateway.cs
+++ b/src/PayEx.EPi.Commerce.Payment/PayExPaymentGateway.cs
@@ -1,4 +1,5 @@
-﻿using System.Web;
+﻿using System;
+using System.Web;
 using EPiServer.ServiceLocation;
 using log4net;
 using Mediachase.Commerce.Orders;
@@ -11,11 +12,13 @@ namespace PayEx.EPi.Commerce.Payment
 {
     public class PayExPaymentGateway : AbstractPaymentGateway
     {
+        private readonly Action<string> _redirectAction;
         protected readonly ILog Log = LogManager.GetLogger(Constants.Logging.DefaultLoggerName);
         private readonly IPaymentMethodFactory _paymentMethodFactory;
 
-        public PayExPaymentGateway()
+        public PayExPaymentGateway(Action<string> redirectAction = null)
         {
+            _redirectAction = redirectAction;
             _paymentMethodFactory = ServiceLocator.Current.GetInstance<IPaymentMethodFactory>();
         }
 
@@ -74,7 +77,7 @@ namespace PayEx.EPi.Commerce.Payment
             }
 
             Log.InfoFormat("Initializing payment with ID:{0} belonging to order with ID: {1}", payment.Id, payment.OrderGroupId);
-            PaymentInitializeResult result = currentPayment.Initialize();
+            PaymentInitializeResult result = currentPayment.Initialize(_redirectAction);
             message = result.ErrorMessage ?? string.Empty;
 
             if (!result.Success)

--- a/tests/PayEx.EPi.Commerce.Payment.UnitTests/Decorators/PaymentInitializers/GenerateOrderNumberTests.cs
+++ b/tests/PayEx.EPi.Commerce.Payment.UnitTests/Decorators/PaymentInitializers/GenerateOrderNumberTests.cs
@@ -34,7 +34,7 @@ namespace PayEx.EPi.Commerce.Payment.UnitTests.Decorators.PaymentInitializers
             creditCard.Payment = paymentMock.Object;
             creditCard.OrderGroupId = 1000;
 
-            _orderNumberGenerator.Initialize(creditCard, null, null, null);
+            _orderNumberGenerator.Initialize(creditCard, null, null, null, null);
 
             Assert.IsNotNullOrEmpty(creditCard.Payment.OrderNumber);
         }
@@ -50,7 +50,7 @@ namespace PayEx.EPi.Commerce.Payment.UnitTests.Decorators.PaymentInitializers
             creditCard.Payment.Description = "Order number: {0}";
             creditCard.OrderGroupId = 1000;
 
-            _orderNumberGenerator.Initialize(creditCard, null, null, null);
+            _orderNumberGenerator.Initialize(creditCard, null, null, null, null);
 
             Assert.AreEqual(creditCard.Payment.Description, "Order number: " + creditCard.Payment.OrderNumber);
         }


### PR DESCRIPTION
My current client does everything with AJAX, and unfortunately since the library currently just changes the existing Response to be a redirect, I get a 302 response code with the Location header populated. This causes me CORS issues since the Location is with PayEx and not my own server, leaving me in a position I am unable to proceed.

My suggested improvement allows you to pass an optional `Action<string>()` into the `PayExPaymentGateway` constructor, which if populated will get the redirect URL and allow me to do what I want with it, and if not provided will revert back to the original behaviour of doing a redirect on the current Response.

Ideally I would have preferred to have changed the returned object from `ProcessPayment` on the `ProcessPayment` method to have an object with this value, but unfortunately that class lies within EPiServer itself, so this is the best solution I could come up with given the circumstances.

I welcome feedback, suggestions, etc.