### PR TITLE
LineItem properties cast and parse

### DIFF
--- a/src/PayEx.EPi.Commerce.Payment/CartHelper.cs
+++ b/src/PayEx.EPi.Commerce.Payment/CartHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Web;
@@ -129,16 +130,24 @@ namespace PayEx.EPi.Commerce.Payment
         internal static decimal GetVatAmount(LineItem lineItem)
         {
             var vatObject = lineItem["LineItemVatAmount"];
-            if (vatObject != null)
-                return (decimal)vatObject;
+            var vatAsDecimal = vatObject as decimal?;
+            if (vatAsDecimal.HasValue)
+                return vatAsDecimal.Value;
+            var vatAsString = vatObject as string;
+            if (vatAsString != null)
+                return decimal.Parse(vatAsString, CultureInfo.InvariantCulture);
             return 0;
         }
 
         internal static decimal GetVatPercentage(LineItem lineItem)
         {
             var vatPercentObject = lineItem["LineItemVatPercentage"];
-            if (vatPercentObject != null)
-                return (decimal)vatPercentObject;
+            var vatPercentAsDecimal = vatPercentObject as decimal?;
+            if (vatPercentAsDecimal.HasValue)
+                return vatPercentAsDecimal.Value;
+            var vatPercentAsString = vatPercentObject as string;
+            if (vatPercentAsString != null)
+                return decimal.Parse(vatPercentAsString, CultureInfo.InvariantCulture);
             return 0;
         }
 


### PR DESCRIPTION
When setting the line item properties `LineItemVatAmount` and `LineItemVatPercentage`, if you call `Cart.AcceptChanges()`, the values will be saved to the database and the values are automatically cast into strings. When trying to cast a string to a decimal, an invalid cast exception will be thrown. Since the value cannot be trusted to remain unchanged, a change is needed to handle both casting and parsing.

The change I have sent will first attempt to safely cast to a decimal, and failing that, attempt to parse.
